### PR TITLE
Add option to use default terminal colour for specific terse elements

### DIFF
--- a/R/ansi.R
+++ b/R/ansi.R
@@ -13,15 +13,15 @@ reset <- "\033[39m\033[49m"
 #' If all the RGB colour components are equal then the colour is matched to one
 #' of 24 grey levels, other wise it is converted to one of 216 standard colours.
 #'
-#' @param rcolour any R colour e.g. 'red', '#445566'
+#' @param rcolour any R colour (e.g. 'red', '#445566') or NA
 #'
 #' @return ANSI escape string for the given colour as a foreground or background
-#'         colour
+#'         colour. If `rcolour` is NULL or NA, returns an empty string.
 #'
 #' @importFrom grDevices col2rgb
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 col2bg <- function(rcolour) {
-  if (is.null(rcolour)) {return('')}
+  if (is.null(rcolour) | is.na(rcolour)) {return('')}
   code <- col2code(rcolour)
   paste0("\033[48;5;", code, "m")
 }
@@ -31,7 +31,7 @@ col2bg <- function(rcolour) {
 #' @rdname col2bg
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 col2fg <- function(rcolour) {
-  if (is.null(rcolour)) {return('')}
+  if (is.null(rcolour) | is.na(rcolour)) {return('')}
   code <- col2code(rcolour)
   paste0("\033[38;5;", code, "m")
 }

--- a/R/ansi.R
+++ b/R/ansi.R
@@ -21,7 +21,7 @@ reset <- "\033[39m\033[49m"
 #' @importFrom grDevices col2rgb
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 col2bg <- function(rcolour) {
-  if (is.null(rcolour) | is.na(rcolour)) {return('')}
+  if (is.null(rcolour) || is.na(rcolour)) {return('')}
   code <- col2code(rcolour)
   paste0("\033[48;5;", code, "m")
 }
@@ -31,7 +31,7 @@ col2bg <- function(rcolour) {
 #' @rdname col2bg
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 col2fg <- function(rcolour) {
-  if (is.null(rcolour) | is.na(rcolour)) {return('')}
+  if (is.null(rcolour) || is.na(rcolour)) {return('')}
   code <- col2code(rcolour)
   paste0("\033[38;5;", code, "m")
 }

--- a/R/terse.R
+++ b/R/terse.R
@@ -116,7 +116,7 @@ build_names <- function(x, width = 10, config = list()) {
 #' @param max_vec_len maximum vector length anywhere in original object
 #' @param config named list of user configuration options
 #' \itemize{
-#' \item{\code{ansi       } - Use ANSI to colour output. default: TRUE}
+#' \item{\code{ansi       } - Use ANSI to colour output. ANSI will be disabled for colours set to NA. default: TRUE}
 #' \item{\code{soft       } - non-highlight colour. default: grey40}
 #' \item{\code{gsep       } - separator for vector output. default: ','}
 #' \item{\code{colour_nth } - colour for every nth vector element. default: blue4}

--- a/man/col2bg.Rd
+++ b/man/col2bg.Rd
@@ -13,11 +13,11 @@ col2fg(rcolour)
 col2code(rcolour)
 }
 \arguments{
-\item{rcolour}{any R colour e.g. 'red', '#445566'}
+\item{rcolour}{any R colour (e.g. 'red', '#445566') or NA}
 }
 \value{
 ANSI escape string for the given colour as a foreground or background
-        colour
+        colour. If `rcolour` is NULL or NA, returns an empty string.
 }
 \description{
 Ref: \url{https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit}

--- a/man/terse.Rd
+++ b/man/terse.Rd
@@ -90,7 +90,7 @@ or a numeric vector the same length as x}
 
 \item{config}{named list of user configuration options
 \itemize{
-\item{\code{ansi       } - Use ANSI to colour output. default: TRUE}
+\item{\code{ansi       } - Use ANSI to colour output. ANSI will be disabled for colours set to NA. default: TRUE}
 \item{\code{soft       } - non-highlight colour. default: grey40}
 \item{\code{gsep       } - separator for vector output. default: ','}
 \item{\code{colour_nth } - colour for every nth vector element. default: blue4}


### PR DESCRIPTION
It can be difficult to make terse's colour config work well when switching between themes.
Particularly when alternating between light and dark themes, a value for `soft` that looks muted on a light theme may be more prominent than `colour_all` on a dark theme.
Currently, this means users who regularly switch between themes may prefer to disable `ansi` colouring.

This pull request allows the user to use the default terminal colour for specific terse elements by setting their colour to `NA`.
The most obvious use case would be setting `colour_all` to `NA`, `soft` to a medium grey, and `colour_type` to a highlight colour.
This preserves the visual structure of terse's colours while performing well on both light and dark themes.

![terse_na_light](https://user-images.githubusercontent.com/44556601/86493770-a2beaa00-bd27-11ea-8db9-62c9d8675cd8.png)
![terse_na_dark](https://user-images.githubusercontent.com/44556601/86493622-085e6680-bd27-11ea-8a7b-999839f8437d.png)

